### PR TITLE
Logger arg message fix

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -67,7 +67,7 @@ function Message(args) {
         if (_.isString(arg)) {
             result.message = result.message ? result.message += ` ${arg}` : arg;
         } else {
-            if(arg.message){
+            if(arg && arg.message){
                 result.message = result.message ? result.message += ` ${arg.message}` : arg.message;
                 delete arg.message;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-framework",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Foundation libraries for nodus based applications.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This resolves a bug that was introduced recently in nodus-framework on 5/20/2016.

Fixing issue on line 70 of `logger.js`.  
- If an argument was passed to the logger as data, and was undefined, then it was failing on the if statement to remove the message.
